### PR TITLE
[RFR] Downgrade min version check

### DIFF
--- a/winrm/__init__.py
+++ b/winrm/__init__.py
@@ -75,7 +75,7 @@ class Session(object):
         """converts a Powershell CLIXML message to a more human readable string
         """
         # TODO prepare unit test, beautify code
-        if sys.version_info[:2] == (3, 7) and not isinstance(msg, text_type):
+        if sys.version_info[:2] >= (3, 6) and not isinstance(msg, text_type):
             msg = msg.decode('utf-8')
         # if the msg does not start with this, return it as is
         if msg.startswith("b#< CLIXML"):


### PR DESCRIPTION
it turned out that some colleagues still use py 3.6. This change should sort out some issues in py 3.6